### PR TITLE
Implement Masuda Method (Increased Shiny Odds)

### DIFF
--- a/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
+++ b/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
@@ -418,7 +418,22 @@ public class PokeBreed {
       baby.setShiny(false);
       // Shinies enabled.
       if (CobblemonConfig.shinyRate > 0) {
-        intRNG = RNG.nextInt(CobblemonConfig.shinyRate);  // 0-shinyRate
+        /* Implement a psuedo-Masuda method, where shiny odds are increased when
+         * at least one Pokémon has a different OT from the breeding user */
+        String pokemon1OT = breederPokemon1.getOriginalTrainer();
+        String pokemon2OT = breederPokemon2.getOriginalTrainer();
+        String breederUUIDString = breederUUID.toString();
+
+        boolean masudaMethod = (pokemon1OT != null && !pokemon1OT.equals(breederUUIDString)) ||
+                (pokemon2OT != null && !pokemon2OT.equals(breederUUIDString));
+
+        int shinyRate = CobblemonConfig.shinyRate;
+        if (masudaMethod) {
+          // Masuda method odds are about 6x as of Gen VI
+          shinyRate = Math.max(1, shinyRate / 6);
+        }
+
+        intRNG = RNG.nextInt(shinyRate);  // 0-shinyRate
         // Hit shiny (1/shinyRate chance).
         if (intRNG == 0) {
           baby.setShiny(true);

--- a/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
+++ b/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
@@ -418,7 +418,7 @@ public class PokeBreed {
       baby.setShiny(false);
       // Shinies enabled.
       if (CobblemonConfig.shinyRate > 0) {
-        /* Implement a psuedo-Masuda method, where shiny odds are increased when
+        /* Implement a pseudo-Masuda method, where shiny odds are increased when
          * at least one Pokémon has a different OT from the breeding user */
         String pokemon1OT = breederPokemon1.getOriginalTrainer();
         String pokemon2OT = breederPokemon2.getOriginalTrainer();

--- a/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
+++ b/common/src/main/java/dev/thomasqtruong/veryscuffedcobblemonbreeding/commands/PokeBreed.java
@@ -263,7 +263,8 @@ public class PokeBreed {
         party.add(baby);
 
         // Send success message and set cooldown.
-        Component toSend = Component.literal("Breed complete!").withStyle(ChatFormatting.GREEN);
+        Component toSend = Component.literal("Breed complete!").withStyle(ChatFormatting.GREEN)
+                .append(baby.getShiny() ? Component.literal(" ★").withStyle(ChatFormatting.GOLD) : Component.empty());
         breeder.sendSystemMessage(toSend);
         // Player has VIP status.
         if (isVIP) {

--- a/common/src/main/kotlin/dev/thomasqtruong/veryscuffedcobblemonbreeding/util/PokemonUtility.kt
+++ b/common/src/main/kotlin/dev/thomasqtruong/veryscuffedcobblemonbreeding/util/PokemonUtility.kt
@@ -124,8 +124,6 @@ object PokemonUtility {
         val moveThree = if (pokemon.moveSet.getMoves().size >= 3) pokemon.moveSet[2]!!.displayName.string else "Empty"
         val moveFour = if (pokemon.moveSet.getMoves().size >= 4) pokemon.moveSet[3]!!.displayName.string else "Empty"
 
-
-
         val itemstack: ItemStack = ItemBuilder(PokemonItem.from(pokemon,1))
             .hideAdditional()
             .addLore(arrayOf<Component>(Component.literal(pokemon.caughtBall.item().defaultInstance.displayName.string).setStyle(Style.EMPTY.withItalic(true).withColor(ChatFormatting.DARK_GRAY)),
@@ -137,6 +135,9 @@ object PokemonUtility {
 
                 Component.literal("Nature: ").withStyle(ChatFormatting.YELLOW).append(lang(pokemon.nature.displayName.replace("cobblemon.", "")).withStyle(ChatFormatting.WHITE)),
                 Component.literal("Ability: ").withStyle(ChatFormatting.GOLD).append(lang(pokemon.ability.displayName.replace("cobblemon.", "")).withStyle(ChatFormatting.WHITE)),
+                Component.literal("OT: ").withStyle(ChatFormatting.RED).append(
+                    Component.literal(pokemon.originalTrainerName ?: "Unknown").withStyle(ChatFormatting.WHITE)
+                ),
                 Component.literal("IVs: ").withStyle(ChatFormatting.LIGHT_PURPLE),
                 Component.literal("  HP: ").withStyle(ChatFormatting.RED).append(Component.literal(pokemon.ivs.getOrDefault(Stats.HP).toString()).withStyle(ChatFormatting.WHITE))
                     .append(Component.literal("  Atk: ").withStyle(ChatFormatting.BLUE).append(Component.literal(pokemon.ivs.getOrDefault(Stats.ATTACK).toString()).withStyle(ChatFormatting.WHITE)))


### PR DESCRIPTION
Implements #15, a pseudo-[Masuda method](https://bulbapedia.bulbagarden.net/wiki/Masuda_method), where if any of the Pokémon being bred are from a different player/OT, the condition increases the shiny rate by 6x (1 in 1365 using the default 8192 full odds Shiny encounter - Gens II-V and the Cobblemon default, or 1 in 683 with the newer 4096 rate - Gen VI and later, if configured). 

This PR also implements:
- "OT" tag on the Pokémon description on hover, to help players know which Pokémon are from a different OT
- Shiny indicator on the "Breed complete! ★" message to help the player know when they've bred a shiny
<img src="https://github.com/user-attachments/assets/ea092b0b-6b7d-4963-9f8f-eb53154a603e" width="300"/><br/>

I also wanted to include a feature where the OT name would be _italicised_ if it matched the player's username, but I couldn't find where/how to retrieve the player's username, so I left this feature out.

Please note that my primary experience is with JavaScript/TypeScript, and this is my first attempt at Java/Kotlin and Minecraft modding in general. I'd appreciate it if you could review my changes thoroughly, although the implementation is so minor that I don't think any issues could arise. I have tested my implementation and can confirm that it functions as expected.

Have a great day!