### PR TITLE
Add Gender Markers to Pokémon Name in Breed Box

### DIFF
--- a/common/src/main/kotlin/dev/thomasqtruong/veryscuffedcobblemonbreeding/util/PokemonUtility.kt
+++ b/common/src/main/kotlin/dev/thomasqtruong/veryscuffedcobblemonbreeding/util/PokemonUtility.kt
@@ -2,6 +2,7 @@ package dev.thomasqtruong.veryscuffedcobblemonbreeding.util
 
 import com.cobblemon.mod.common.api.pokemon.stats.Stats
 import com.cobblemon.mod.common.item.PokemonItem
+import com.cobblemon.mod.common.pokemon.Gender
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.cobblemon.mod.common.util.lang
 import net.minecraft.ChatFormatting
@@ -160,7 +161,19 @@ object PokemonUtility {
                 Component.literal("Form: ").withStyle(ChatFormatting.GOLD).append(pokemon.form.name)
             ))
             .setCustomName(
-                if (pokemon.shiny) pokemon.species.translatedName.copy().withStyle(ChatFormatting.GRAY).append(Component.literal(" ★").withStyle(ChatFormatting.GOLD)) else pokemon.species.translatedName.copy().withStyle(ChatFormatting.GRAY)
+                pokemon.species.translatedName.copy().withStyle(ChatFormatting.GRAY)
+                    .append(
+                        when (pokemon.gender) {
+                            Gender.MALE -> Component.literal(" ♂").withStyle(ChatFormatting.BLUE)
+                            Gender.FEMALE -> Component.literal(" ♀").withStyle(ChatFormatting.LIGHT_PURPLE)
+                            Gender.GENDERLESS -> Component.literal(" ")
+                        }
+                    )
+                    .append(
+                        if (pokemon.shiny) {
+                            Component.literal("★").withStyle(ChatFormatting.GOLD)
+                        } else Component.empty()
+                    ),
             )
             .build()
         return itemstack


### PR DESCRIPTION
This PR adds binary gendered markers (♂♀) to the suffix of a Pokémon's name when hovering over them in the breeding box. This helps the player easily identify the gender of a Pokémon without needing to check it first in the PC.

<img width="300" src="https://github.com/user-attachments/assets/2428743d-0f39-4b84-a7a8-d531049d6e9c" />
<img width="300" src="https://github.com/user-attachments/assets/9c3b4183-057f-4d19-8977-398098c04c51" />
<img width="300" src="https://github.com/user-attachments/assets/e9ca161b-d435-4ff6-8485-a044cb5ab23c" />
<img width="300" src="https://github.com/user-attachments/assets/73357245-5765-4667-a2f2-625098bf4518" />
